### PR TITLE
refactor: migrate inputs to flake-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ❄️ nixfiles
 
-Declarative NixOS configurations built with [flake-parts](https://flake.parts/) and [den](https://den.denful.dev/).
+Declarative NixOS configurations built with [flake-parts](https://flake.parts/), [den](https://den.denful.dev/), and [flake-file](https://github.com/denful/flake-file).
 
 This repo follows Den’s current host/user/aspect model:
 
@@ -10,7 +10,8 @@ This repo follows Den’s current host/user/aspect model:
 
 ## How this repo is structured
 
-- `flake.nix` wires in `inputs.den.flakeModule`
+- `flake-file.nix` declares flake inputs for the generated `flake.nix`
+- `outputs.nix` is the hand-written flake entrypoint
 - `modules/den.nix` enables Den and registers the local `nf` namespace
 - `modules/hosts/*` defines hosts such as `fw13` and `vulkan`
 - `modules/users/*` defines user aspects, mainly `kid`
@@ -96,14 +97,21 @@ Stage a boot entry instead of switching immediately:
 just boot fw13
 ```
 
+Regenerate `flake.nix` after changing flake inputs:
+
+```bash
+just write
+```
+
 Run flake checks:
 
 ```bash
-nix flake check
+just check
 ```
 
 ## Main dependencies
 
+- [flake-file](https://github.com/denful/flake-file) for generating `flake.nix` from typed module options
 - [den](https://den.denful.dev/) for the host/user/aspect pipeline
 - [home-manager](https://github.com/nix-community/home-manager) for user environments
 - [disko](https://github.com/nix-community/disko) for declarative partitioning
@@ -112,10 +120,3 @@ nix flake check
 - [plasma-manager](https://github.com/nix-community/plasma-manager) for KDE configuration
 - [sops-nix](https://github.com/Mic92/sops-nix) for secrets
 - [treefmt-nix](https://github.com/numtide/treefmt-nix) for formatting
-
-## Credits
-
-This setup has been heavily inspired by:
-
-- [isabelroses/dotfiles](https://github.com/isabelroses/dotfiles)
-- [jakehamilton/config](https://github.com/jakehamilton/config)

--- a/flake.lock
+++ b/flake.lock
@@ -292,43 +292,6 @@
         "type": "github"
       }
     },
-    "disko_2": {
-      "inputs": {
-        "nixpkgs": [
-          "nixos-anywhere",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1779699611,
-        "narHash": "sha256-EcCaSTKnmg2o4wLKaN1aqQFomwyhO7ik0bX9COdyCas=",
-        "owner": "nix-community",
-        "repo": "disko",
-        "rev": "5ba0c9555c28685e57fa54c7a25e42c7efdbfc8d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "master",
-        "repo": "disko",
-        "type": "github"
-      }
-    },
-    "easy-hosts": {
-      "locked": {
-        "lastModified": 1779046777,
-        "narHash": "sha256-pwM/welCvrTZwJFGhDFfZBD2WtbW1rUk+NTBv91rlEA=",
-        "owner": "tgirlcloud",
-        "repo": "easy-hosts",
-        "rev": "218aa628740073cbaf136a3c4cfcdc90a61dd84f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tgirlcloud",
-        "repo": "easy-hosts",
-        "type": "github"
-      }
-    },
     "fenix": {
       "inputs": {
         "nixpkgs": [
@@ -439,25 +402,26 @@
         "type": "github"
       }
     },
-    "flake-compat_4": {
-      "flake": false,
+    "flake-file": {
       "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "lastModified": 1779051720,
+        "narHash": "sha256-+jbXnODsR19pFKB0x/6kHhFgW6yV6N+CGClFr45eDU8=",
+        "owner": "denful",
+        "repo": "flake-file",
+        "rev": "c58eb27d9434e5be0c8693f1eb18d47035bc21ba",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
+        "owner": "denful",
+        "repo": "flake-file",
         "type": "github"
       }
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1778716662,
@@ -538,7 +502,7 @@
     },
     "flake-parts_4": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
         "lastModified": 1733312601,
@@ -556,7 +520,7 @@
     },
     "flake-parts_5": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_3"
+        "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
         "lastModified": 1741352980,
@@ -574,7 +538,7 @@
     },
     "flake-parts_6": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_4"
+        "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
         "lastModified": 1772408722,
@@ -614,7 +578,7 @@
     },
     "flake-parts_8": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_5"
+        "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
         "lastModified": 1778716662,
@@ -669,7 +633,7 @@
     },
     "git-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_2",
         "gitignore": "gitignore_2",
         "nixpkgs": [
           "nix-gaming",
@@ -978,89 +942,6 @@
         "type": "github"
       }
     },
-    "niri": {
-      "inputs": {
-        "niri-stable": "niri-stable",
-        "niri-unstable": "niri-unstable",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable",
-        "xwayland-satellite-stable": "xwayland-satellite-stable",
-        "xwayland-satellite-unstable": "xwayland-satellite-unstable"
-      },
-      "locked": {
-        "lastModified": 1780062130,
-        "narHash": "sha256-3XF+oy0PX4aajJw2RNB8rlMpyu0eXCG4pGH7fe94yBg=",
-        "owner": "sodiboo",
-        "repo": "niri-flake",
-        "rev": "3cb351d73c357a4e413f59c4551d219118791c14",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sodiboo",
-        "repo": "niri-flake",
-        "type": "github"
-      }
-    },
-    "niri-stable": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1756556321,
-        "narHash": "sha256-RLD89dfjN0RVO86C/Mot0T7aduCygPGaYbog566F0Qo=",
-        "owner": "YaLTeR",
-        "repo": "niri",
-        "rev": "01be0e65f4eb91a9cd624ac0b76aaeab765c7294",
-        "type": "github"
-      },
-      "original": {
-        "owner": "YaLTeR",
-        "ref": "v25.08",
-        "repo": "niri",
-        "type": "github"
-      }
-    },
-    "niri-unstable": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1780056110,
-        "narHash": "sha256-t7lKVshV/srD0G06j4r5P5qj9zaDeZ9JYFCxHDGROZU=",
-        "owner": "YaLTeR",
-        "repo": "niri",
-        "rev": "f9f43d826ab4014a7c302be28d7da33e12f5be37",
-        "type": "github"
-      },
-      "original": {
-        "owner": "YaLTeR",
-        "repo": "niri",
-        "type": "github"
-      }
-    },
-    "nix-citizen": {
-      "inputs": {
-        "flake-compat": "flake-compat_2",
-        "nix-gaming": [
-          "nix-gaming"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "treefmt-nix": "treefmt-nix_3"
-      },
-      "locked": {
-        "lastModified": 1780102376,
-        "narHash": "sha256-/AY1hlAixYPPuT38ldUkYzKBp7oP3tA45+7MBK+23JI=",
-        "owner": "LovingMelody",
-        "repo": "nix-citizen",
-        "rev": "dfd985404c9632f57a0cc16654c270a772839351",
-        "type": "github"
-      },
-      "original": {
-        "owner": "LovingMelody",
-        "repo": "nix-citizen",
-        "type": "github"
-      }
-    },
     "nix-gaming": {
       "inputs": {
         "flake-parts": "flake-parts_8",
@@ -1103,88 +984,6 @@
         "type": "github"
       }
     },
-    "nix-vm-test": {
-      "inputs": {
-        "nixpkgs": [
-          "nixos-anywhere",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1779799925,
-        "narHash": "sha256-kMBQRZjb2A+qVpuNCiRoqMhDElkP/jR2m9Lu7PAt7M4=",
-        "owner": "numtide",
-        "repo": "nix-vm-test",
-        "rev": "d41d806a5c9699ab9cbac5a698aac889c83fa57e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-vm-test",
-        "type": "github"
-      }
-    },
-    "nixlib": {
-      "locked": {
-        "lastModified": 1736643958,
-        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixos-anywhere": {
-      "inputs": {
-        "disko": "disko_2",
-        "nix-vm-test": "nix-vm-test",
-        "nixos-images": "nixos-images",
-        "nixos-stable": "nixos-stable",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "treefmt-nix": "treefmt-nix_4"
-      },
-      "locked": {
-        "lastModified": 1779867678,
-        "narHash": "sha256-b2sjqQRofVAxpCi5lxUJ4Hg7vN/Avng1lxdjbdM4JMA=",
-        "owner": "nix-community",
-        "repo": "nixos-anywhere",
-        "rev": "354eea27536cf7354fe0ff59bd1a69634fa428cf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-anywhere",
-        "type": "github"
-      }
-    },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": "nixlib",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769813415,
-        "narHash": "sha256-nnVmNNKBi1YiBNPhKclNYDORoHkuKipoz7EtVnXO50A=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "8946737ff703382fda7623b9fab071d037e897d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
     "nixos-hardware": {
       "inputs": {
         "nixpkgs": "nixpkgs_5"
@@ -1200,47 +999,6 @@
       "original": {
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "type": "github"
-      }
-    },
-    "nixos-images": {
-      "inputs": {
-        "nixos-stable": [
-          "nixos-anywhere",
-          "nixos-stable"
-        ],
-        "nixos-unstable": [
-          "nixos-anywhere",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778754897,
-        "narHash": "sha256-UlPBPrqOYTDB9g/8pUaIUzYpGgjQL/YMK3Ein6m9DkY=",
-        "owner": "nix-community",
-        "repo": "nixos-images",
-        "rev": "66fe34a02cc29c825fdb4ece1a79c17e8f2ade2e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-images",
-        "type": "github"
-      }
-    },
-    "nixos-stable": {
-      "locked": {
-        "lastModified": 1779622335,
-        "narHash": "sha256-ViA62qtL5za7V3d5I8OA9q9JcFhsVAiL5jVHwEclWqk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "705e9929918b43bd7b715dc0a878ac870449bb03",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-26.05",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -1262,21 +1020,6 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib_2": {
-      "locked": {
         "lastModified": 1733096140,
         "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
         "type": "tarball",
@@ -1287,7 +1030,7 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
       }
     },
-    "nixpkgs-lib_3": {
+    "nixpkgs-lib_2": {
       "locked": {
         "lastModified": 1740877520,
         "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
@@ -1302,7 +1045,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_4": {
+    "nixpkgs-lib_3": {
       "locked": {
         "lastModified": 1772328832,
         "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
@@ -1317,7 +1060,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_5": {
+    "nixpkgs-lib_4": {
       "locked": {
         "lastModified": 1777168982,
         "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
@@ -1329,22 +1072,6 @@
       "original": {
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -1474,13 +1201,13 @@
       "locked": {
         "lastModified": 1775856943,
         "narHash": "sha256-b7Mp7P+q2Md5AGt4rjHfMcBykzMumFTen10ST++AuTU=",
-        "owner": "pjones",
+        "owner": "nix-community",
         "repo": "plasma-manager",
         "rev": "a524a6160e6df89f7673ba293cf7d78b559eb1a5",
         "type": "github"
       },
       "original": {
-        "owner": "pjones",
+        "owner": "nix-community",
         "ref": "trunk",
         "repo": "plasma-manager",
         "type": "github"
@@ -1514,7 +1241,7 @@
     },
     "pre-commit-hooks-nix_2": {
       "inputs": {
-        "flake-compat": "flake-compat_4",
+        "flake-compat": "flake-compat_3",
         "gitignore": "gitignore_3",
         "nixpkgs": [
           "nixpkgs"
@@ -1555,7 +1282,7 @@
         "darwin": "darwin",
         "den": "den",
         "disko": "disko",
-        "easy-hosts": "easy-hosts",
+        "flake-file": "flake-file",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",
         "impermanence": "impermanence",
@@ -1563,12 +1290,8 @@
         "lanzaboote": "lanzaboote",
         "llm-agents": "llm-agents",
         "neovim-flake": "neovim-flake",
-        "niri": "niri",
-        "nix-citizen": "nix-citizen",
         "nix-gaming": "nix-gaming",
         "nix-gaming-edge": "nix-gaming-edge",
-        "nixos-anywhere": "nixos-anywhere",
-        "nixos-generators": "nixos-generators",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_6",
         "nur": "nur",
@@ -1577,7 +1300,7 @@
         "preservation": "preservation",
         "sops-nix": "sops-nix",
         "stylix": "stylix",
-        "treefmt-nix": "treefmt-nix_5",
+        "treefmt-nix": "treefmt-nix_3",
         "ucodenix": "ucodenix",
         "xremap": "xremap"
       }
@@ -1846,48 +1569,6 @@
     "treefmt-nix_3": {
       "inputs": {
         "nixpkgs": [
-          "nix-citizen",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_4": {
-      "inputs": {
-        "nixpkgs": [
-          "nixos-anywhere",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_5": {
-      "inputs": {
-        "nixpkgs": [
           "nixpkgs"
         ]
       },
@@ -1962,39 +1643,6 @@
         "owner": "k0kubun",
         "ref": "v0.15.7",
         "repo": "xremap",
-        "type": "github"
-      }
-    },
-    "xwayland-satellite-stable": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1755491097,
-        "narHash": "sha256-m+9tUfsmBeF2Gn4HWa6vSITZ4Gz1eA1F5Kh62B0N4oE=",
-        "owner": "Supreeeme",
-        "repo": "xwayland-satellite",
-        "rev": "388d291e82ffbc73be18169d39470f340707edaa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Supreeeme",
-        "ref": "v0.7",
-        "repo": "xwayland-satellite",
-        "type": "github"
-      }
-    },
-    "xwayland-satellite-unstable": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1779745227,
-        "narHash": "sha256-yqY7RtEJGJiENzR0GwL6q69tSAy6xAAmAcLuIhLjPf8=",
-        "owner": "Supreeeme",
-        "repo": "xwayland-satellite",
-        "rev": "5d1efbc9dc3ab1c10160b656e0247f3325daf0f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Supreeeme",
-        "repo": "xwayland-satellite",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,89 +1,90 @@
+# DO-NOT-EDIT. This file was auto-generated using github:vic/flake-file.
+# Use `nix run .#write-flake` to regenerate it.
 {
+  outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } (inputs.import-tree ./modules);
+
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-
-    flake-parts.url = "github:hercules-ci/flake-parts";
-    easy-hosts.url = "github:tgirlcloud/easy-hosts";
-
-    disko.url = "github:nix-community/disko/latest";
-    disko.inputs.nixpkgs.follows = "nixpkgs";
-
-    nixos-generators.url = "github:nix-community/nixos-generators";
-    nixos-generators.inputs.nixpkgs.follows = "nixpkgs";
-
-    ucodenix.url = "github:e-tho/ucodenix";
-
-    nixos-hardware.url = "github:nixos/nixos-hardware";
-
-    nixos-anywhere.url = "github:nix-community/nixos-anywhere";
-    nixos-anywhere.inputs.nixpkgs.follows = "nixpkgs";
-
+    dagger = {
+      url = "github:dagger/nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    darwin = {
+      url = "github:lnl7/nix-darwin/master";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    den.url = "github:denful/den";
+    disko = {
+      url = "github:nix-community/disko/latest";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-file.url = "github:denful/flake-file";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     impermanence.url = "github:nix-community/impermanence";
+    import-tree.url = "github:vic/import-tree";
+    lanzaboote = {
+      url = "github:nix-community/lanzaboote/v0.4.3";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    llm-agents = {
+      url = "github:numtide/llm-agents.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    neovim-flake.url = "github:kid/neovim";
+    nix-gaming = {
+      url = "github:fufexan/nix-gaming";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nix-gaming-edge = {
+      url = "github:powerofthe69/nix-gaming-edge";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nixos-hardware.url = "github:nixos/nixos-hardware";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nur = {
+      url = "github:nix-community/NUR";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    plasma-manager = {
+      url = "github:nix-community/plasma-manager/trunk";
+      inputs = {
+        home-manager.follows = "home-manager";
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+    pre-commit-hooks-nix = {
+      url = "github:cachix/pre-commit-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     preservation.url = "github:nix-community/preservation";
-
-    home-manager.url = "github:nix-community/home-manager";
-    home-manager.inputs.nixpkgs.follows = "nixpkgs";
-
-    darwin.url = "github:lnl7/nix-darwin/master";
-    darwin.inputs.nixpkgs.follows = "nixpkgs";
-
-    treefmt-nix.url = "github:numtide/treefmt-nix";
-    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
-
-    pre-commit-hooks-nix.url = "github:cachix/pre-commit-hooks.nix";
-    pre-commit-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
-
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     stylix = {
       url = "github:danth/stylix";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nur.follows = "nur";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        nur.follows = "nur";
+      };
     };
-
-    nix-gaming.url = "github:fufexan/nix-gaming";
-    nix-gaming.inputs.nixpkgs.follows = "nixpkgs";
-
-    nix-gaming-edge.url = "github:powerofthe69/nix-gaming-edge";
-    nix-gaming-edge.inputs.nixpkgs.follows = "nixpkgs";
-
-    nix-citizen.url = "github:LovingMelody/nix-citizen";
-    nix-citizen.inputs.nixpkgs.follows = "nixpkgs";
-    nix-citizen.inputs.nix-gaming.follows = "nix-gaming";
-
-    nur.url = "github:nix-community/NUR";
-    nur.inputs.nixpkgs.follows = "nixpkgs";
-
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    ucodenix.url = "github:e-tho/ucodenix";
     xremap = {
       url = "github:xremap/nix-flake";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-parts.follows = "flake-parts";
+      inputs = {
+        flake-parts.follows = "flake-parts";
+        nixpkgs.follows = "nixpkgs";
+      };
     };
-
-    neovim-flake.url = "github:kid/neovim";
-
-    plasma-manager = {
-      url = "github:pjones/plasma-manager/trunk";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.home-manager.follows = "home-manager";
-    };
-
-    sops-nix.url = "github:Mic92/sops-nix";
-    sops-nix.inputs.nixpkgs.follows = "nixpkgs";
-
-    lanzaboote.url = "github:nix-community/lanzaboote/v0.4.3";
-    lanzaboote.inputs.nixpkgs.follows = "nixpkgs";
-
-    niri.url = "github:sodiboo/niri-flake";
-    niri.inputs.nixpkgs.follows = "nixpkgs";
-
-    dagger.url = "github:dagger/nix";
-    dagger.inputs.nixpkgs.follows = "nixpkgs";
-
-    llm-agents.url = "github:numtide/llm-agents.nix";
-    llm-agents.inputs.nixpkgs.follows = "nixpkgs";
-
-    import-tree.url = "github:vic/import-tree";
-    den.url = "github:denful/den";
   };
-
-  outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } (inputs.import-tree ./modules);
 }

--- a/justfile
+++ b/justfile
@@ -3,6 +3,12 @@ hostname := `hostname -s`
 help:
   just -l
 
+check:
+  nix flake check
+
+write:
+  nix run \.#write-flake
+
 build host=hostname *args:
   nix run \#{{host}} build -- {{args}}
 

--- a/modules/den.nix
+++ b/modules/den.nix
@@ -1,7 +1,17 @@
 { inputs, den, ... }:
 {
+  flake-file.inputs = {
+    den.url = "github:denful/den";
+    flake-file.url = "github:denful/flake-file";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
   imports = [
-    inputs.den.flakeModule
+    (inputs.flake-file.flakeModules.dendritic or { })
+    (inputs.den.flakeModules.dendritic or { })
     (inputs.den.namespace "nf" true)
   ];
 

--- a/modules/flake-file.nix
+++ b/modules/flake-file.nix
@@ -1,0 +1,39 @@
+{
+  flake-file.inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    disko.url = "github:nix-community/disko/latest";
+    disko.inputs.nixpkgs.follows = "nixpkgs";
+
+    nixos-hardware.url = "github:nixos/nixos-hardware";
+
+    impermanence.url = "github:nix-community/impermanence";
+    preservation.url = "github:nix-community/preservation";
+
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+
+    darwin.url = "github:lnl7/nix-darwin/master";
+    darwin.inputs.nixpkgs.follows = "nixpkgs";
+
+    pre-commit-hooks-nix.url = "github:cachix/pre-commit-hooks.nix";
+    pre-commit-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
+
+    nur.url = "github:nix-community/NUR";
+    nur.inputs.nixpkgs.follows = "nixpkgs";
+
+    neovim-flake.url = "github:kid/neovim";
+
+    sops-nix.url = "github:Mic92/sops-nix";
+    sops-nix.inputs.nixpkgs.follows = "nixpkgs";
+
+    lanzaboote.url = "github:nix-community/lanzaboote/v0.4.3";
+    lanzaboote.inputs.nixpkgs.follows = "nixpkgs";
+
+    dagger.url = "github:dagger/nix";
+    dagger.inputs.nixpkgs.follows = "nixpkgs";
+
+    llm-agents.url = "github:numtide/llm-agents.nix";
+    llm-agents.inputs.nixpkgs.follows = "nixpkgs";
+  };
+}

--- a/modules/flake/formatter.nix
+++ b/modules/flake/formatter.nix
@@ -1,5 +1,10 @@
 { inputs, ... }:
 {
+  flake-file.inputs.treefmt-nix = {
+    url = "github:numtide/treefmt-nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+
   imports = [ inputs.treefmt-nix.flakeModule ];
 
   perSystem = {
@@ -30,6 +35,5 @@
         ];
       };
     };
-
   };
 }

--- a/modules/hosts/fw13/default.nix
+++ b/modules/hosts/fw13/default.nix
@@ -22,15 +22,8 @@
       { config, pkgs, ... }:
       {
         imports = [
-          inputs.niri.nixosModules.niri
           inputs.nixos-hardware.nixosModules.framework-amd-ai-300-series
         ];
-
-        nixpkgs = {
-          overlays = [
-            inputs.niri.overlays.niri
-          ];
-        };
 
         users.users.kid = {
           extraGroups = lib.mkAfter [

--- a/modules/nixfiles/base/firmware.nix
+++ b/modules/nixfiles/base/firmware.nix
@@ -1,0 +1,12 @@
+{ inputs, ... }:
+{
+  flake-file.inputs = {
+    ucodenix.url = "github:e-tho/ucodenix";
+  };
+
+  nf.base.nixos = {
+    imports = [ inputs.ucodenix.nixosModules.default ];
+
+    services.ucodenix.enable = true;
+  };
+}

--- a/modules/nixfiles/base/main.nix
+++ b/modules/nixfiles/base/main.nix
@@ -26,11 +26,7 @@
         inputs.disko.nixosModules.disko
         inputs.impermanence.nixosModules.impermanence
         inputs.preservation.nixosModules.preservation
-        inputs.ucodenix.nixosModules.default
         inputs.sops-nix.nixosModules.sops
-        inputs.nix-gaming.nixosModules.wine
-        inputs.nix-gaming.nixosModules.pipewireLowLatency
-        inputs.nix-gaming.nixosModules.platformOptimizations
         inputs.lanzaboote.nixosModules.lanzaboote
       ];
 
@@ -243,7 +239,6 @@
           jack.enable = true;
           pulse.enable = true;
           wireplumber.enable = true;
-          lowLatency.enable = true;
         };
 
         pulseaudio.enable = lib.mkForce false;

--- a/modules/nixfiles/desktop/gaming.nix
+++ b/modules/nixfiles/desktop/gaming.nix
@@ -5,10 +5,24 @@
   ...
 }:
 {
+  flake-file.inputs = {
+    nix-gaming.url = "github:fufexan/nix-gaming";
+    nix-gaming.inputs.nixpkgs.follows = "nixpkgs";
+
+    nix-gaming-edge.url = "github:powerofthe69/nix-gaming-edge";
+    nix-gaming-edge.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
   nf.desktop.gaming = {
     nixos =
       { pkgs, ... }:
       {
+        imports = with inputs.nix-gaming.nixosModules; [
+          wine
+          pipewireLowLatency
+          platformOptimizations
+        ];
+
         nix.settings = {
           extra-substituters = [ "https://nix-cache.tokidoki.dev/tokidoki" ];
           extra-trusted-public-keys = [ "tokidoki:MD4VWt3kK8Fmz3jkiGoNRJIW31/QAm7l1Dcgz2Xa4hk=" ];
@@ -67,6 +81,8 @@
           };
         };
 
+        services.pipewire.lowLatency.enable = true;
+
         environment.sessionVariables = {
           MESA_VK_WSI_PRESENT_MODE = "immediate";
           PROTON_USE_NTSYNC = 1;
@@ -81,7 +97,7 @@
             programs.gamescope.args = lib.mkAfter [ "--expose-wayland" ];
           };
 
-        homeManager = _: {
+        homeManager = {
           home.sessionVariables = {
             PROTON_ENABLE_WAYLAND = "1";
             PROTON_ENABLE_HDR = "1";

--- a/modules/nixfiles/desktop/plasma.nix
+++ b/modules/nixfiles/desktop/plasma.nix
@@ -5,6 +5,12 @@
   ...
 }:
 {
+  flake-file.inputs.plasma-manager = {
+    url = "github:nix-community/plasma-manager/trunk";
+    inputs.nixpkgs.follows = "nixpkgs";
+    inputs.home-manager.follows = "home-manager";
+  };
+
   nf.desktop.plasma = {
     includes = [ nf.desktop.wayland ];
     nixos = {
@@ -64,6 +70,8 @@
         };
 
         gtk.gtk4.theme = config.gtk.theme;
+
+        # TODO: should this be dependend on nf.desktop.plasma or even move there?
         qt.platformTheme.name = lib.mkForce "kde";
       };
   };

--- a/modules/nixfiles/desktop/xremap.nix
+++ b/modules/nixfiles/desktop/xremap.nix
@@ -5,6 +5,12 @@
   ...
 }:
 {
+  flake-file.inputs.xremap = {
+    url = "github:xremap/nix-flake";
+    inputs.nixpkgs.follows = "nixpkgs";
+    inputs.flake-parts.follows = "flake-parts";
+  };
+
   nf.desktop.xremap = {
     nixos = {
       imports = [ inputs.xremap.nixosModules.default ];

--- a/modules/nixfiles/stylix/main.nix
+++ b/modules/nixfiles/stylix/main.nix
@@ -1,37 +1,38 @@
 { inputs, lib, ... }:
-let
-  mod =
-    { pkgs, ... }:
-    {
-      stylix = {
-        enable = true;
-        image = lib.mkDefault ./gruvbox-dark-rainbow.png;
-        base16Scheme = lib.mkDefault "${pkgs.base16-schemes}/share/themes/gruvbox-dark-medium.yaml";
-        fonts = {
-          monospace = {
-            name = lib.mkDefault "JetBrainsMono Nerd Font Propo";
-            package = lib.mkDefault pkgs.nerd-fonts.jetbrains-mono;
-          };
-          sizes.terminal = lib.mkDefault 11;
-        };
-        polarity = lib.mkDefault "dark";
-      };
-    };
-in
 {
-  nf.stylix.nixos = {
-    imports = [
-      inputs.stylix.nixosModules.stylix
-      mod
-    ];
-
-    stylix.targets.qt.enable = lib.mkDefault false;
+  flake-file.inputs.stylix = {
+    url = "github:danth/stylix";
+    inputs.nixpkgs.follows = "nixpkgs";
+    inputs.nur.follows = "nur";
   };
 
-  nf.stylix.darwin = {
-    imports = [
-      inputs.stylix.darwinModules.stylix
-      mod
-    ];
+  nf.stylix = {
+    os =
+      { pkgs, ... }:
+      {
+        stylix = {
+          enable = true;
+          image = lib.mkDefault ./gruvbox-dark-rainbow.png;
+          base16Scheme = lib.mkDefault "${pkgs.base16-schemes}/share/themes/gruvbox-dark-medium.yaml";
+          fonts = {
+            monospace = {
+              name = lib.mkDefault "JetBrainsMono Nerd Font Propo";
+              package = lib.mkDefault pkgs.nerd-fonts.jetbrains-mono;
+            };
+            sizes.terminal = lib.mkDefault 11;
+          };
+          polarity = lib.mkDefault "dark";
+        };
+      };
+
+    nixos = {
+      imports = [ inputs.stylix.nixosModules.stylix ];
+
+      stylix.targets.qt.enable = lib.mkDefault false;
+    };
+
+    darwin = {
+      imports = [ inputs.stylix.darwinModules.stylix ];
+    };
   };
 }


### PR DESCRIPTION
## Summary
- migrate the repo to denful/flake-file and generate `flake.nix` from module-defined inputs
- move flake input declarations closer to the modules that use them
- add `just write` and `just check` helpers and update the README
- split firmware/gaming/stylix related input wiring into their own modules

## Testing
- just write
- just check
