### PR TITLE
fix: resolve vulkan disko device arg via plain import

### DIFF
--- a/modules/hosts/vulkan/default.nix
+++ b/modules/hosts/vulkan/default.nix
@@ -19,7 +19,7 @@
 
     nixos.imports = [
       ./_configuration.nix
-      ./_disko-config.nix
+      (import ./_disko-config.nix { })
     ]
     ++ (with inputs.nixos-hardware.nixosModules; [
       common-pc


### PR DESCRIPTION
## Summary
- `_disko-config.nix` takes `device` as a function arg with a default (`device ? "/dev/disk/by-id/..."`), but `default.nix` imported it as a bare module path, letting the NixOS module system inject `device` via `_module.args` instead of applying the local default.
- Disko's own `gpt.nix` submodule also requires a no-default `device` arg from `_module.args`. Since both share the same arg name in the global `_module.args` namespace, the module system treats `device` as required everywhere, silently shadowing this file's own default.
- This never broke `nixos-rebuild switch`/`build`, since those never force `disko.devices.disk.main.device`. It only surfaces when something actually builds disko's mount/format/create scripts — e.g. running disko's CLI in mount mode to reinstall the bootloader from a live ISO without reformatting, which is how I hit it.
- Fix: call the function directly with plain Nix (`import ./_disko-config.nix { }`) so the default resolves immediately into a concrete value, instead of importing it as a module function.

## Test plan
- [x] Reproduced the failure reinstalling the bootloader for `vulkan` from a NixOS ISO via `disko --mode mount --flake .#vulkan`
- [x] Confirmed the fix resolves it and the disk mounts successfully
- [ ] `nix flake check` (not yet re-run post-push)