### PR TITLE
feat: split nf.ai into a base aspect and nf.ai.pi

### DIFF
--- a/modules/nixfiles/ai/default.nix
+++ b/modules/nixfiles/ai/default.nix
@@ -1,0 +1,28 @@
+{ inputs, ... }:
+{
+  nf.ai = {
+    os = {
+      nix.settings = {
+        extra-substituters = [ "https://cache.numtide.com" ];
+        extra-trusted-public-keys = [
+          "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
+        ];
+      };
+
+      nixpkgs.overlays = [
+        inputs.llm-agents.overlays.default
+      ];
+    };
+
+    homeManager =
+      {
+        pkgs,
+        ...
+      }:
+      {
+        home.packages = with pkgs.llm-agents; [
+          claude-code
+        ];
+      };
+  };
+}

--- a/modules/nixfiles/ai/pi.nix
+++ b/modules/nixfiles/ai/pi.nix
@@ -1,18 +1,7 @@
-{ inputs, ... }:
+{ nf, ... }:
 {
   nf.ai.pi = {
-    os = {
-      nix.settings = {
-        extra-substituters = [ "https://cache.numtide.com" ];
-        extra-trusted-public-keys = [
-          "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
-        ];
-      };
-
-      nixpkgs.overlays = [
-        inputs.llm-agents.overlays.default
-      ];
-    };
+    includes = [ nf.ai ];
 
     homeManager =
       {

--- a/modules/users/kid.nix
+++ b/modules/users/kid.nix
@@ -13,7 +13,7 @@
       nf.batteries.privileged-user
       nf.apps._
       nf.shell.zsh
-      # nf.ai.pi
+      nf.ai
       nf.desktop
       nf.desktop.xremap
       nf.desktop.plasma


### PR DESCRIPTION
## Summary
- New `nf.ai` aspect (`modules/nixfiles/ai/default.nix`) holds the shared llm-agents overlay, cache substituter, and `claude-code` package — previously baked directly into `nf.ai.pi`.
- `nf.ai.pi` now `includes nf.ai` and keeps only its own pi-specific home-manager config (stylix theme file, `pi` package).
- `kid.nix` now includes `nf.ai` directly, enabling the base AI tooling (claude-code) rather than the previously commented-out `nf.ai.pi`.

## Test plan
- [ ] `nix flake check`
- [ ] `just build fw13` / `just build vulkan` to confirm `kid`'s home-manager config still evaluates