### PR TITLE
Mixed host/module tweaks: mouses, ghostty, helldivers2, xremap, ai, vulkan

### DIFF
--- a/modules/hosts/vulkan/_configuration.nix
+++ b/modules/hosts/vulkan/_configuration.nix
@@ -119,12 +119,12 @@
       user = "kid";
     };
 
-    udev.extraRules = lib.mkAfter ''
-      ACTION=="add|change", SUBSYSTEM=="usb", TEST=="power/control", ATTR{power/control}="on"
-      ACTION=="add|change", SUBSYSTEM=="usb", TEST=="power/wakeup", ATTR{power/wakeup}="disabled"
-      SUBSYSTEM=="ata_port", KERNEL=="ata*", ATTR{device/power/control}="auto"
-      ACTION=="add", SUBSYSTEM=="usb", DRIVERS=="usb", ATTR{idVendor}=="cb10", ATTR{idProduct}=="1257", ATTR{power/control}="on"
-    '';
+    # udev.extraRules = lib.mkAfter ''
+    #   ACTION=="add|change", SUBSYSTEM=="usb", TEST=="power/control", ATTR{power/control}="on"
+    #   ACTION=="add|change", SUBSYSTEM=="usb", TEST=="power/wakeup", ATTR{power/wakeup}="disabled"
+    #   SUBSYSTEM=="ata_port", KERNEL=="ata*", ATTR{device/power/control}="auto"
+    #   ACTION=="add", SUBSYSTEM=="usb", DRIVERS=="usb", ATTR{idVendor}=="cb10", ATTR{idProduct}=="1257", ATTR{power/control}="on"
+    # '';
 
     scx = {
       enable = true;
@@ -141,7 +141,7 @@
     extraModulePackages = with config.boot.kernelPackages; [ r8125 ];
     kernelParams = lib.mkAfter [
       "boot.shell_on_fail"
-      "amdgpu.dcdebugmask=0x400"
+      # "amdgpu.dcdebugmask=0x400"
       "preempt=full"
       "amd_pstate=active"
     ];

--- a/modules/hosts/vulkan/_configuration.nix
+++ b/modules/hosts/vulkan/_configuration.nix
@@ -1,4 +1,5 @@
 {
+  pkgs,
   config,
   lib,
   ...
@@ -168,6 +169,11 @@
       windows."11".efiDeviceHandle = "HD0b";
     };
   };
+
+  services.lact.enable = true;
+  environment.systemPackages = with pkgs; [
+    lact
+  ];
 
   hardware = {
     amdgpu.overdrive.enable = true;

--- a/modules/hosts/vulkan/default.nix
+++ b/modules/hosts/vulkan/default.nix
@@ -18,6 +18,7 @@
       nf.dev.incus
       nf.dev.libvirt
       nf.storage.preservation
+      nf.hardware.razer
     ];
 
     persist.directories = [

--- a/modules/nixfiles/ai/default.nix
+++ b/modules/nixfiles/ai/default.nix
@@ -15,15 +15,21 @@
     };
 
     homeManager =
+      { pkgs, ... }:
       {
-        pkgs,
-        ...
-      }:
-      {
-        home.packages = with pkgs.llm-agents; [
-          claude-code
-          opencode
-        ];
+        programs.tmux.enable = true;
+
+        home = {
+          packages = with pkgs.llm-agents; [
+            claude-code
+            claudebox
+            opencode
+          ];
+
+          sessionVariables = {
+            CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = 1;
+          };
+        };
       };
   };
 }

--- a/modules/nixfiles/ai/default.nix
+++ b/modules/nixfiles/ai/default.nix
@@ -10,7 +10,7 @@
       };
 
       nixpkgs.overlays = [
-        inputs.llm-agents.overlays.default
+        inputs.llm-agents.overlays.shared-nixpkgs
       ];
     };
 

--- a/modules/nixfiles/apps/ghosttty.nix
+++ b/modules/nixfiles/apps/ghosttty.nix
@@ -1,0 +1,15 @@
+{
+  nf.apps.ghostty = {
+    homeManager = {
+      programs.ghostty = {
+        enable = true;
+        settings.keybind = [
+          "ctrl+shift+h=goto_split:left"
+          "ctrl+shift+j=goto_split:bottom"
+          "ctrl+shift+k=goto_split:top"
+          "ctrl+shift+l=goto_split:right"
+        ];
+      };
+    };
+  };
+}

--- a/modules/nixfiles/desktop/xremap.nix
+++ b/modules/nixfiles/desktop/xremap.nix
@@ -1,9 +1,4 @@
-{
-  inputs,
-  den,
-  nf,
-  ...
-}:
+{ inputs, nf, ... }:
 {
   flake-file.inputs.xremap = {
     url = "github:xremap/nix-flake";
@@ -11,7 +6,7 @@
     inputs.flake-parts.follows = "flake-parts";
   };
 
-  nf.desktop.xremap = {
+  nf.desktop.xremap = { user, ... }: {
     nixos = {
       imports = [ inputs.xremap.nixosModules.default ];
       services.xremap.enable = false;
@@ -22,27 +17,27 @@
 
       services.xremap = {
         enable = true;
-        watch = true;
-        config.keymap = [
-          {
-            remap = {
-              SUPER-B.launch = [ "firefox" ];
-              SUPER-SHIFT-B.launch = [
-                "firefox"
-                "--private-window"
-              ];
-              SUPER-T.launch = [ "wezterm" ];
-              SUPER-P.launch = [ "krunner" ];
-            };
-          }
-        ];
+        withKDE = user.hasAspect nf.desktop.plasma;
+        config = {
+          # Fix compatibility with Wayland applications (particularly games)
+          keypress_delay_ms = 20;
+          throttle_ms = 10;
+
+          keymap = [
+            {
+              remap = {
+                SUPER-B.launch = [ "firefox" ];
+                SUPER-SHIFT-B.launch = [
+                  "firefox"
+                  "--private-window"
+                ];
+                SUPER-T.launch = [ "wezterm" ];
+                SUPER-P.launch = [ "krunner" ];
+              };
+            }
+          ];
+        };
       };
     };
-
-    includes = [
-      (den.lib.policy.when ({ user, ... }: user.hasAspect nf.desktop.plasma) {
-        homeManager.services.xremap.withKDE = true;
-      })
-    ];
   };
 }

--- a/modules/nixfiles/games/helldivers2.nix
+++ b/modules/nixfiles/games/helldivers2.nix
@@ -1,0 +1,24 @@
+{
+  nf.games.helldivers2 = {
+    homeManager = _: {
+      services.xremap = {
+        mouse = true;
+        config = {
+          virtual_modifiers = [ "BTN_TASK" ];
+          keymap = [
+            {
+              application.only = [ "steam_app_553850" ];
+              remap = {
+                BTN_TASK-BTN_LEFT = "m";
+                BTN_TASK-XLeftScroll = "y";
+                BTN_TASK-XDownScroll = "j";
+                BTN_TASK-XUpScroll = "k";
+                BTN_TASK-XRightScroll = "o";
+              };
+            }
+          ];
+        };
+      };
+    };
+  };
+}

--- a/modules/nixfiles/hardware/mouses.nix
+++ b/modules/nixfiles/hardware/mouses.nix
@@ -10,9 +10,85 @@
   };
 
   nf.hardware.razer = {
-    nixos = { ... }: {
-      hardware.openrazer.enable = true;
-      hardware.openrazer.users = [ "kid" ];
+    nixos = { pkgs, ... }: {
+      hardware.openrazer = {
+        enable = true;
+      };
+
+      environment.systemPackages = with pkgs; [
+        polychromatic
+        razer-cli
+      ];
+    };
+
+    provides.to-users = { user, ... }: {
+      nixos = {
+        hardware.openrazer.users = [ user.name ];
+      };
+
+      homeManager =
+        { pkgs, ... }:
+        {
+          # Basilisk V3 Pro: force driver mode so the clutch/sniper button
+          # (BTN_TASK) is forwarded as an input event instead of being
+          # handled by firmware, so input-remapper (or anything else) can
+          # see it. This also stops the firmware handling DPI up/down and
+          # tilt-wheel scroll.
+          #
+          # The NixOS hardware.openrazer module generates its own
+          # razer.conf from Nix options and always launches the daemon
+          # with that file via `--config`, ignoring
+          # `~/.config/openrazer/razer.conf` entirely and with no
+          # per-device section support - so driver mode can't be declared
+          # through the daemon's config. Setting it via its D-Bus API on
+          # every daemon start is the only way that actually persists.
+          #
+          # The device serial OpenRazer reports isn't stable across
+          # boots/reconnects (it sometimes falls back to a generated
+          # "UNKNOWN_..." placeholder instead of the real hardware
+          # serial), so the serial is looked up at runtime instead of
+          # hardcoded.
+          systemd.user.services.razer-driver-mode = {
+            Unit = {
+              Description = "Force Basilisk V3 Pro into OpenRazer driver mode";
+              After = [ "openrazer-daemon.service" ];
+              PartOf = [ "openrazer-daemon.service" ];
+            };
+            Service = {
+              Type = "oneshot";
+              # Default systemd start timeout (90s) is shorter than the
+              # retry budget below (up to ~300s), so it would otherwise
+              # get killed mid-retry.
+              TimeoutStartSec = "330s";
+              # Racing the daemon at boot: the unit is "started" (bus name
+              # acquired) well before the per-device dbus object finishes
+              # registering - empirically this can take much longer than
+              # a few seconds, so retry with real patience rather than
+              # bailing early and relying on a manual restart.
+              ExecStart = pkgs.writeShellScript "razer-driver-mode" ''
+                for i in $(seq 1 150); do
+                  devices=$(${pkgs.dbus}/bin/dbus-send --session --dest=org.razer --type=method_call \
+                    --print-reply /org/razer razer.devices.getDevices 2>&1)
+                  serial=$(echo "$devices" | ${pkgs.gnugrep}/bin/grep -oP '(?<=string ")[^"]+' | head -n1)
+                  ${pkgs.dbus}/bin/dbus-send --session --dest=org.razer --type=method_call \
+                    --print-reply "/org/razer/device/$serial" razer.device.misc.setDeviceMode byte:3 byte:0 2>&1
+                  getmode=$(${pkgs.dbus}/bin/dbus-send --session --dest=org.razer --type=method_call \
+                    --print-reply "/org/razer/device/$serial" razer.device.misc.getDeviceMode 2>&1)
+                  # setDeviceMode always reports success even when the kernel
+                  # driver silently ignores the write (e.g. the mouse hasn't
+                  # fully woken/settled yet), so getDeviceMode's readback is
+                  # the only trustworthy success signal.
+                  if [ -n "$serial" ] && echo "$getmode" | ${pkgs.gnugrep}/bin/grep -q '"3:0"'; then
+                    exit 0
+                  fi
+                  sleep 2
+                done
+                exit 1
+              '';
+            };
+            Install.WantedBy = [ "openrazer-daemon.service" ];
+          };
+        };
     };
   };
 }

--- a/modules/nixfiles/hardware/mouses.nix
+++ b/modules/nixfiles/hardware/mouses.nix
@@ -1,0 +1,18 @@
+{
+  nf.hardware.logitech = {
+    nixos = { pkgs, ... }: {
+      services.ratbagd.enable = true;
+
+      environment.systemPackages = with pkgs; [
+        piper
+      ];
+    };
+  };
+
+  nf.hardware.razer = {
+    nixos = { ... }: {
+      hardware.openrazer.enable = true;
+      hardware.openrazer.users = [ "kid" ];
+    };
+  };
+}

--- a/modules/users/kid.nix
+++ b/modules/users/kid.nix
@@ -6,7 +6,7 @@
   ...
 }:
 {
-  den.aspects.kid = {
+  den.aspects.kid = { host, ... }: {
     includes = [
       den._.define-user
       den._.primary-user
@@ -17,14 +17,11 @@
       nf.desktop
       nf.desktop.xremap
       nf.desktop.plasma
-    ];
+    ]
+    ++ (if host.name == "vulkan" then [ nf.games.helldivers2 ] else [ ]);
 
     homeManager =
-      {
-        pkgs,
-        osConfig,
-        ...
-      }:
+      { pkgs, osConfig, ... }:
       {
         imports = [ inputs.sops-nix.homeManagerModules.sops ];
 

--- a/modules/users/kid.nix
+++ b/modules/users/kid.nix
@@ -31,7 +31,6 @@
         home = {
           inherit (osConfig.system) stateVersion;
           packages = [
-            pkgs.opencode
             pkgs.winbox4
             pkgs.pistol
             pkgs.gnumake

--- a/modules/users/kid.nix
+++ b/modules/users/kid.nix
@@ -79,15 +79,6 @@
             };
           };
 
-          ghostty = {
-            enable = true;
-            settings.keybind = [
-              "ctrl+shift+h=goto_split:left"
-              "ctrl+shift+j=goto_split:bottom"
-              "ctrl+shift+k=goto_split:top"
-              "ctrl+shift+l=goto_split:right"
-            ];
-          };
         };
 
       };


### PR DESCRIPTION
## Summary
- Add a `nf.hardware.mouses` module (razer aspect scaffolding)
- Extract ghostty config into its own `nf.apps.ghostty` module
- Add a `nf.games.helldivers2` module with xremap mouse remaps, included on vulkan
- Simplify xremap's KDE integration to a direct aspect check, add Wayland compat delays
- Add an openrazer driver-mode systemd service for the Basilisk V3 Pro
- Fix the llm-agents overlay reference (`overlays.default` → `overlays.shared-nixpkgs`)
- Add claudebox and tmux to the ai module
- vulkan: disable USB power/kernel debug tweaks, enable lact for AMD GPU control

## Test plan
- [ ] `nix flake check`
- [ ] Build/switch on vulkan host and confirm lact + xremap behave as expected