### PR TITLE
feat(ai): add nixd LSP server for Claude Code

### DIFF
--- a/modules/nixfiles/ai/claude.nix
+++ b/modules/nixfiles/ai/claude.nix
@@ -45,6 +45,13 @@
                 ".go" = "go";
               };
             };
+
+            nix = {
+              command = lib.getExe pkgs.nixd;
+              extensionToLanguage = {
+                ".nix" = "nix";
+              };
+            };
           };
         };
       };


### PR DESCRIPTION
## Summary
- Add `nixd` as the LSP server for `.nix` files in the claude-code config, matching the existing `go` and `typescript` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)